### PR TITLE
Rename attribute 'checkedButton' to 'checkedToggleButton'

### DIFF
--- a/library/src/main/java/androidx/appcompat/widget/ToggleGroup.java
+++ b/library/src/main/java/androidx/appcompat/widget/ToggleGroup.java
@@ -123,7 +123,7 @@ public class ToggleGroup extends LinearLayoutCompat
                     : getResources().getColor(R.color.toggleGroup_dark_background));
         }
 
-        int value = attributes.getResourceId(R.styleable.ToggleGroup_checkedButton, View.NO_ID);
+        int value = attributes.getResourceId(R.styleable.ToggleGroup_checkedToggleButton, View.NO_ID);
         if (value != NO_ID) {
             addCheckedId(value); // We set this even if not exclusive to help with designer
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -3,7 +3,7 @@
     <declare-styleable name="ToggleGroup">
         <!-- The id of the child radio button that should be checked by default
              within this radio group. -->
-        <attr name="checkedButton" format="integer" />
+        <attr name="checkedToggleButton" format="integer" />
         <!-- Should the radio group be a column or a row?  Use "horizontal"
              for a row, "vertical" for a column.  The default is
              horizontal. -->


### PR DESCRIPTION
Rename attribute `checkedButton` to `checkedToggleButton` to avoid build fails because of name duplicate when using `ToggleButtons` and `com.google.android.material:material:1.1.0-alpha07` library simultaneously. 
I tested the sample app with implementation of the `android.material` library, and after renaming it builds and runs fine.
If there is something I should change about this pull request just tell me, as I am quite new to GitHub and coding.